### PR TITLE
c++-property-fix CXX_FLAGS and get_property issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include (${HPCC_GM_SOURCE_DIR}/cmake_modules/gmCommonSetup.cmake)
 include (${HPCC_SOURCE_DIR}/version.cmake)
 
 
-SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti -fPIC -fmessage-length=0 -Wformat -Wformat-security -Wformat-nonliteral -pthread -Wuninitialized")
+SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti -fPIC -fmessage-length=0 -Wformat -Wformat-security -Wformat-nonliteral -pthread -Wuninitialized -std=c++11")
 
 MESSAGE (HPCC_SOURCE_DIR: ${HPCC_SOURCE_DIR})
 ADD_SUBDIRECTORY(${HPCC_SOURCE_DIR} oss EXCLUDE_FROM_ALL)

--- a/esp/scm/additional.cmake
+++ b/esp/scm/additional.cmake
@@ -22,8 +22,6 @@
 
 set ( ESPSCM_SOURCE_DIR ${HPCC_GM_SOURCE_DIR}/esp/scm )
 set ( ESPSCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
-GET_TARGET_PROPERTY(HIDL_EXE hidl LOCATION)
-GET_TARGET_PROPERTY(ESDL-XML_EXE esdl-xml LOCATION)
 
 set ( ESPSCM_SRCS
       ws_rrd.ecm
@@ -34,11 +32,11 @@ foreach ( loop_var ${ESPSCM_SRCS} )
 #    if (SCM_BUILD)
       add_custom_command ( DEPENDS hidl ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.esp ${ESPSCM_GENERATED_DIR}/${result}.hpp ${ESPSCM_GENERATED_DIR}/${result}.int ${ESPSCM_GENERATED_DIR}/${result}.ipp ${ESPSCM_GENERATED_DIR}/${result}_esp.cpp ${ESPSCM_GENERATED_DIR}/${result}_esp.ipp
-                           COMMAND ${HIDL_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:hidl> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
       add_custom_command ( DEPENDS esdl-xml ${ESPSCM_SOURCE_DIR}/${loop_var}
                            OUTPUT ${ESPSCM_GENERATED_DIR}/${result}.xml
-                           COMMAND ${ESDL-XML_EXE} ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
+                           COMMAND $<TARGET_FILE:esdl-xml> ${ESPSCM_SOURCE_DIR}/${result}.ecm ${ESPSCM_GENERATED_DIR}
                          )
  #   endif ()
     set_source_files_properties(${ESPSCM_GENERATED_DIR}/${result}.esp PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
@garonsky, I ran into a possible issue when I was going through my Jira list and seeing if https://track.hpccsystems.com/browse/HPCC-14297 was still a problem for ganglia.  I noticed that the additional.cmake file was still using the get_property() function that's deprecated.  Also that the -std=c++11 flag for the compiler wasn't set.  I know you were talking about using c++11 the other day so I assume you might have fixed this in master, but just in case.  

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
