### PR TITLE
HPCC-21227 Install Ganglia-monitoring configuration files

### DIFF
--- a/esp/src/CMakeLists.txt
+++ b/esp/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-#    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+#    HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-HPCC_ADD_SUBDIRECTORY (scm)
-HPCC_ADD_SUBDIRECTORY (services/ws_rrd)
-HPCC_ADD_SUBDIRECTORY (src)
+HPCC_ADD_SUBDIRECTORY (ganglia)

--- a/esp/src/ganglia/CMakeLists.txt
+++ b/esp/src/ganglia/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-#    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+#   HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -13,6 +13,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ################################################################################
-HPCC_ADD_SUBDIRECTORY (scm)
-HPCC_ADD_SUBDIRECTORY (services/ws_rrd)
-HPCC_ADD_SUBDIRECTORY (src)
+SET (GANGLIA_SOURCE_DIR "${HPCC_SOURCE_DIR}/esp/src/ganglia")
+
+FOREACH( iFILES
+        ${GANGLIA_SOURCE_DIR}/GangliaFilterDropDownWidget.js
+        ${GANGLIA_SOURCE_DIR}/GangliaWidget.js
+        ${GANGLIA_SOURCE_DIR}/ws_rrd.js
+        ${GANGLIA_SOURCE_DIR}/ganglia.json
+)
+
+        INSTALL( FILES ${iFILES} DESTINATION componentfiles/files/ganglia COMPONENT Runtime )
+ENDFOREACH( iFILES )


### PR DESCRIPTION
Ganglia-monitoring is broken in HPCC 7.0.4-1 or earlier versions. The reason is that ganglia.json and related files are missing in the Ganglia-monitoring package.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@kenrowland please review.

Test build: http://10.240.32.243/view/custom/job/CE-Ganglia-JIRA-HPCC-21227/
I tested on Ubutnu 16.04 with HPCC Platform master build.
