### PR TITLE
HPCC-24779 Fix ganglia-monitoring build isssue caused by persistent.hpp

### DIFF
--- a/esp/services/ws_rrd/CMakeLists.txt
+++ b/esp/services/ws_rrd/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/esp/http/platform
          ${HPCC_SOURCE_DIR}/system/mp
          ${HPCC_SOURCE_DIR}/system/xmllib
+         ${HPCC_SOURCE_DIR}/common/thorhelper
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
          ${CMAKE_BINARY_DIR}/esp/services/ws_rrd


### PR DESCRIPTION
- Add common/thorhelper to the include path of ws_rrd

Signed-off-by: Yanrui Ma <yanrui.ma@lexisnexisrisk.com>